### PR TITLE
Use /usr/bin/env node in hashbang

### DIFF
--- a/prod-packages/yamrt/src/cli.js
+++ b/prod-packages/yamrt/src/cli.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 
 require('./yamrt');


### PR DESCRIPTION
It is the standard to use env as different distributions have different paths for node

[optimist](https://www.npmjs.com/package/optimist) for instance has examples that all show usage of `/usr/bin/env node`